### PR TITLE
add seed, model and snapshot for auto exposure testing

### DIFF
--- a/models/staging/auto_exposure_test/first_auto_exposure_model.sql
+++ b/models/staging/auto_exposure_test/first_auto_exposure_model.sql
@@ -1,0 +1,17 @@
+{{ config(materialized='table') }}
+
+-- updating the range will increase the number of rows in the table, 
+-- making it possible to check whether the rebuilt table is flowing through to the downstream exposure
+{% for i in range(10) %}
+
+    select {{ i }} as number,
+    getdate() as model_built_at,
+    {{ env_var('DBT_CLOUD_RUN_ID', -1) }} as dbt_cloud_run_id,
+
+    {{ dbt_utils.generate_surrogate_key(['number', 'model_built_at', 'dbt_cloud_run_id']) }} as unique_key
+
+    {% if not loop.last %}
+        union all 
+    {% endif %}
+    
+{% endfor %}

--- a/seeds/a_seed_for_an_auto_exposure_to_use.csv
+++ b/seeds/a_seed_for_an_auto_exposure_to_use.csv
@@ -1,0 +1,4 @@
+id,word
+1,apple
+2,banana
+3,coconut

--- a/snapshots/auto_exposure_snapshot.yml
+++ b/snapshots/auto_exposure_snapshot.yml
@@ -1,0 +1,8 @@
+snapshots:
+  - name: first_auto_exposure_snapshot
+    relation: ref('first_auto_exposure_model')
+    config:
+      schema: snapshots
+      strategy: check
+      unique_key: unique_key
+      check_cols: ['unique_key']


### PR DESCRIPTION
The active exposures team is connecting to this project to refresh data extracts in Tableau when the auto-discovered exposures' tables have been built, but the TPCH dataset is static so they can't check if it is working! 

This adds a model with a configurable number of rows, plus a snapshot of that table and a standard seed, to check various node types all are discovered correctly. 