### PR TITLE
feat: add all materialization types (built-in + 2 custom)

### DIFF
--- a/macros/materializations/secure_view.sql
+++ b/macros/materializations/secure_view.sql
@@ -1,0 +1,18 @@
+{%- materialization secure_view, adapter='snowflake' -%}
+
+  {%- set target_relation = this.incorporate(type='view') -%}
+  {%- set existing_relation = load_cached_relation(this) -%}
+
+  {% if existing_relation is not none %}
+    {{ adapter.drop_relation(existing_relation) }}
+  {% endif %}
+
+  {% call statement('main') -%}
+    create or replace secure view {{ target_relation }} as (
+      {{ sql }}
+    )
+  {%- endcall %}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{%- endmaterialization -%}

--- a/macros/materializations/transient_table.sql
+++ b/macros/materializations/transient_table.sql
@@ -1,0 +1,18 @@
+{%- materialization transient_table, adapter='snowflake' -%}
+
+  {%- set target_relation = this.incorporate(type='table') -%}
+  {%- set existing_relation = load_cached_relation(this) -%}
+
+  {% if existing_relation is not none %}
+    {{ adapter.drop_relation(existing_relation) }}
+  {% endif %}
+
+  {% call statement('main') -%}
+    create or replace transient table {{ target_relation }} as (
+      {{ sql }}
+    )
+  {%- endcall %}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{%- endmaterialization -%}

--- a/models/marts/_marts_models.yml
+++ b/models/marts/_marts_models.yml
@@ -18,6 +18,7 @@ models:
     description: changing this to public to verify dbt parse does not work
     config:
       access: public
+      materialized: view
   - name: duplicate_for_groups_transactions
     description: all the transactions you could dream of, enriched by customer and store data from the core dbt project
     columns:
@@ -25,3 +26,32 @@ models:
     config:
       group: paul_group_access_only
       access: private
+
+  - name: fct_daily_sales
+    description: incremental daily sales aggregation by date and item
+    columns:
+      - name: sale_date_item_key
+        tests:
+          - unique
+          - not_null
+    config:
+      materialized: incremental
+      unique_key: sale_date_item_key
+      incremental_strategy: merge
+
+  - name: agg_sales_by_item
+    description: item-level sales aggregation as a Snowflake dynamic table
+    config:
+      materialized: dynamic_table
+      snowflake_warehouse: COMPUTE_WH
+      target_lag: downstream
+
+  - name: secure_customer_sales
+    description: restricted sales view using Snowflake secure view materialization
+    config:
+      materialized: secure_view
+
+  - name: tmp_sales_snapshot
+    description: point-in-time sales data using Snowflake transient table materialization
+    config:
+      materialized: transient_table

--- a/models/marts/agg_sales_by_item.sql
+++ b/models/marts/agg_sales_by_item.sql
@@ -1,0 +1,7 @@
+select
+    item_sk,
+    sum(sales_price) as total_sales,
+    count(*) as num_transactions,
+    avg(sales_price) as avg_sales_price
+from {{ ref('int_sales__unioned') }}
+group by 1

--- a/models/marts/fct_daily_sales.sql
+++ b/models/marts/fct_daily_sales.sql
@@ -1,0 +1,27 @@
+with
+
+current_dates as (
+    select * from {{ ref('stg_tpcds_core__current_year_dates') }}
+),
+
+sales as (
+    select
+        sold_date_sk,
+        item_sk,
+        sum(sales_price) as total_sales,
+        count(*) as num_transactions
+    from {{ ref('int_sales__unioned') }}
+    where sold_date_sk in (select date_sk from current_dates)
+    {% if is_incremental() %}
+        and sold_date_sk > (select max(sold_date_sk) from {{ this }})
+    {% endif %}
+    group by 1, 2
+)
+
+select
+    {{ dbt_utils.generate_surrogate_key(['sold_date_sk', 'item_sk']) }} as sale_date_item_key,
+    sold_date_sk,
+    item_sk,
+    total_sales,
+    num_transactions
+from sales

--- a/models/marts/secure_customer_sales.sql
+++ b/models/marts/secure_customer_sales.sql
@@ -1,0 +1,6 @@
+select
+    customer_sk,
+    transaction_type,
+    sales_price,
+    sold_date_sk
+from {{ ref('int_sales__unioned') }}

--- a/models/marts/tmp_sales_snapshot.sql
+++ b/models/marts/tmp_sales_snapshot.sql
@@ -1,0 +1,8 @@
+select
+    sale_id,
+    transaction_type,
+    item_sk,
+    customer_sk,
+    sales_price,
+    sold_date_sk
+from {{ ref('int_sales__unioned') }}

--- a/models/staging/auto_exposure_test/_auto_exposure_models.yml
+++ b/models/staging/auto_exposure_test/_auto_exposure_models.yml
@@ -1,0 +1,4 @@
+models:
+  - name: first_auto_exposure_model
+    config:
+      materialized: table

--- a/models/staging/auto_exposure_test/first_auto_exposure_model.sql
+++ b/models/staging/auto_exposure_test/first_auto_exposure_model.sql
@@ -1,5 +1,3 @@
-{{ config(materialized='table') }}
-
 -- updating the range will increase the number of rows in the table, 
 -- making it possible to check whether the rebuilt table is flowing through to the downstream exposure
 {% for i in range(10) %}

--- a/models/staging/tpcds_core/_tpcds_models.yml
+++ b/models/staging/tpcds_core/_tpcds_models.yml
@@ -138,3 +138,9 @@ models:
           - not_null
     config:
       group: staging_models
+
+  - name: stg_tpcds_core__current_year_dates
+    description: ephemeral CTE filtering date_dim to current-year rows only
+    config:
+      materialized: ephemeral
+      group: staging_models

--- a/models/staging/tpcds_core/stg_tpcds_core__current_year_dates.sql
+++ b/models/staging/tpcds_core/stg_tpcds_core__current_year_dates.sql
@@ -1,0 +1,3 @@
+select *
+from {{ ref('stg_tpcds_core__date_dim') }}
+where current_year = 'Y'


### PR DESCRIPTION
## Summary

- Add models covering every standard dbt materialization type (`view`, `table`, `incremental`, `ephemeral`, `dynamic_table`) plus two custom Snowflake materializations (`secure_view`, `transient_table`)
- All materialization configs are in YAML files, not SQL `config()` blocks
- The manifest validator (introduced in #40) now passes all required checks

**Stacked on #40** (`meta-5862/local-dbt-tooling`)

To enable testing https://dbtlabs.atlassian.net/browse/META-5862

## What changed

### Custom materialization macros (2 files)
- `macros/materializations/secure_view.sql` -- Snowflake `CREATE SECURE VIEW`
- `macros/materializations/transient_table.sql` -- Snowflake `CREATE TRANSIENT TABLE`

### New models (5 files)
| Model | Materialization | Notes |
|-------|----------------|-------|
| `fct_daily_sales` | `incremental` | Surrogate key via `dbt_utils`, merge strategy |
| `stg_tpcds_core__current_year_dates` | `ephemeral` | Filters date_dim to current year |
| `agg_sales_by_item` | `dynamic_table` | Snowflake-specific, replaces `materialized_view` |
| `secure_customer_sales` | `secure_view` | Custom materialization |
| `tmp_sales_snapshot` | `transient_table` | Custom materialization |

### Config changes (4 files)
- `models/marts/_marts_models.yml` -- Added `materialized: view` for `stg_tpcds_core__date_dim` + configs for 4 new models
- `models/staging/tpcds_core/_tpcds_models.yml` -- Added `ephemeral` config for `stg_tpcds_core__current_year_dates`
- `models/staging/auto_exposure_test/_auto_exposure_models.yml` -- New YAML for `first_auto_exposure_model` (table)
- `models/staging/auto_exposure_test/first_auto_exposure_model.sql` -- Removed inline `config()` block

## Test plan

- [x] `scripts/with-local-dbt.sh parse` succeeds with all new models
- [x] `python scripts/verify_manifest.py` reports all required checks passing
- [x] Validator identifies: 4 core + 1 Snowflake + 2 custom materializations